### PR TITLE
de_x_sie: Korrekter Verweis auf die AUTHORS.md-Datei

### DIFF
--- a/language/de_x_sie/acp/attachments.php
+++ b/language/de_x_sie/acp/attachments.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/ban.php
+++ b/language/de_x_sie/acp/ban.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/board.php
+++ b/language/de_x_sie/acp/board.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/bots.php
+++ b/language/de_x_sie/acp/bots.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/common.php
+++ b/language/de_x_sie/acp/common.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/database.php
+++ b/language/de_x_sie/acp/database.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/email.php
+++ b/language/de_x_sie/acp/email.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/extensions.php
+++ b/language/de_x_sie/acp/extensions.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/forums.php
+++ b/language/de_x_sie/acp/forums.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/groups.php
+++ b/language/de_x_sie/acp/groups.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/language.php
+++ b/language/de_x_sie/acp/language.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/modules.php
+++ b/language/de_x_sie/acp/modules.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/permissions.php
+++ b/language/de_x_sie/acp/permissions.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/permissions_phpbb.php
+++ b/language/de_x_sie/acp/permissions_phpbb.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/posting.php
+++ b/language/de_x_sie/acp/posting.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/profile.php
+++ b/language/de_x_sie/acp/profile.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/prune.php
+++ b/language/de_x_sie/acp/prune.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/search.php
+++ b/language/de_x_sie/acp/search.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/styles.php
+++ b/language/de_x_sie/acp/styles.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/acp/users.php
+++ b/language/de_x_sie/acp/users.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/app.php
+++ b/language/de_x_sie/app.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/captcha_qa.php
+++ b/language/de_x_sie/captcha_qa.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/captcha_recaptcha.php
+++ b/language/de_x_sie/captcha_recaptcha.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/common.php
+++ b/language/de_x_sie/common.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/groups.php
+++ b/language/de_x_sie/groups.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/help_bbcode.php
+++ b/language/de_x_sie/help_bbcode.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/help_faq.php
+++ b/language/de_x_sie/help_faq.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/install.php
+++ b/language/de_x_sie/install.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/mcp.php
+++ b/language/de_x_sie/mcp.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/memberlist.php
+++ b/language/de_x_sie/memberlist.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/migrator.php
+++ b/language/de_x_sie/migrator.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/plupload.php
+++ b/language/de_x_sie/plupload.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/posting.php
+++ b/language/de_x_sie/posting.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/search.php
+++ b/language/de_x_sie/search.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/search_ignore_words.php
+++ b/language/de_x_sie/search_ignore_words.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/search_synonyms.php
+++ b/language/de_x_sie/search_synonyms.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/ucp.php
+++ b/language/de_x_sie/ucp.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/viewforum.php
+++ b/language/de_x_sie/viewforum.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 

--- a/language/de_x_sie/viewtopic.php
+++ b/language/de_x_sie/viewtopic.php
@@ -10,7 +10,7 @@
 * the docs/CREDITS.txt file.
 *
 * Deutsche Übersetzung durch die Übersetzer-Gruppe von phpBB.de:
-* siehe language/de/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
+* siehe language/de_x_sie/AUTHORS.md und https://www.phpbb.de/go/ubersetzerteam
 *
 */
 


### PR DESCRIPTION
`find . -type f -name "*.php" -exec sed -i "s#language/de/AUTHORS.md#language/de_x_sie/AUTHORS.md#g" {} \;`
