### PR TITLE
Ersetze "Account" mit "Benutzerkonto" (zuvor: 3.1.4 Korrekturvorschläge)

### DIFF
--- a/language/de/acp/users.php
+++ b/language/de/acp/users.php
@@ -46,7 +46,7 @@ $lang = array_merge($lang, array(
 	'BAN_ALREADY_ENTERED'	=> 'Die Sperre wurde bereits früher erfolgreich erstellt. Die Liste der Sperren wurde nicht aktualisiert.',
 	'BAN_SUCCESSFUL'		=> 'Sperre erfolgreich hinzugefügt.',
 
-	'CANNOT_BAN_ANONYMOUS'			=> 'Du kannst den Gast-Account nicht sperren. Berechtigungen für Gäste können im Register „Berechtigungen“ geändert werden.',
+	'CANNOT_BAN_ANONYMOUS'			=> 'Du kannst das Gast-Benutzerkonto nicht sperren. Berechtigungen für Gäste können im Register „Berechtigungen“ geändert werden.',
 	'CANNOT_BAN_FOUNDER'			=> 'Du kannst keine Gründer sperren.',
 	'CANNOT_BAN_YOURSELF'			=> 'Du kannst dich nicht selber sperren.',
 	'CANNOT_DEACTIVATE_BOT'			=> 'Du kannst keine Benutzerkonten von Bots deaktivieren. Deaktiviere stattdessen den Bot in den Einstellungen für Spiders/Robots.',

--- a/language/de/common.php
+++ b/language/de/common.php
@@ -319,7 +319,7 @@ $lang = array_merge($lang, array(
 		2	=> '%d unsichtbare Mitglieder',
 	),
 	'HIDDEN_USERS_TOTAL'		=> array(
-		1	=> '%d unsichtbares',
+		1	=> '%d unsichtbarer',
 		2	=> '%d unsichtbare',
 	),
 	'HIDE_GUESTS'					=> 'Gäste ausblenden',

--- a/language/de/email/admin_welcome_activated.txt
+++ b/language/de/email/admin_welcome_activated.txt
@@ -4,6 +4,6 @@ Hallo {USERNAME},
 
 dein Benutzerkonto auf „{SITENAME}“ wurde von einem Administrator aktiviert. Du kannst dich nun anmelden.
 
-Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Account zugeordnet ist, zurücksetzen lassen.
+Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 {EMAIL_SIG}

--- a/language/de/email/admin_welcome_inactive.txt
+++ b/language/de/email/admin_welcome_inactive.txt
@@ -10,9 +10,9 @@ Benutzername: {USERNAME}
 Board-URL:    {U_BOARD}
 ----------------------------
 
-Dein Account ist momentan inaktiv und muss erst durch einen Administrator des Boards aktiviert werden, bevor du ihn verwenden kannst. Es wird eine weitere E-Mail versandt, sobald dies geschehen ist.
+Dein Benutzerkonto ist momentan inaktiv und muss erst durch einen Administrator des Boards aktiviert werden, bevor du es verwenden kannst. Es wird eine weitere E-Mail versandt, sobald dies geschehen ist.
 
-Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Account zugeordnet ist, zurücksetzen lassen.
+Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für deine Registrierung.
 

--- a/language/de/email/coppa_resend_inactive.txt
+++ b/language/de/email/coppa_resend_inactive.txt
@@ -32,9 +32,9 @@ Datum: _______________
 
 -------------------------- HIER AUSSCHNEIDEN -------------------------
 
-Sobald der Administrator dieses Formular per Fax oder Post erhalten hat, wird er deinen Account aktivieren.
+Sobald der Administrator dieses Formular per Fax oder Post erhalten hat, wird er dein Benutzerkonto aktivieren.
 
-Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Account zugeordnet ist, zurücksetzen lassen.
+Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für deine Registrierung.
 

--- a/language/de/email/coppa_welcome_inactive.txt
+++ b/language/de/email/coppa_welcome_inactive.txt
@@ -32,9 +32,9 @@ Datum: _______________
 
 -------------------------- HIER AUSSCHNEIDEN -------------------------
 
-Sobald der Administrator dieses Formular per Fax oder Post erhalten hat, wird er deinen Account aktivieren.
+Sobald der Administrator dieses Formular per Fax oder Post erhalten hat, wird er dein Benutzerkonto aktivieren.
 
-Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Account zugeordnet ist, zurücksetzen lassen.
+Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für deine Registrierung.
 

--- a/language/de/email/installed.txt
+++ b/language/de/email/installed.txt
@@ -4,7 +4,7 @@ Herzlichen Glückwunsch!
 
 Du hast phpBB erfolgreich auf deinem Server installiert.
 
-Diese E-Mail enthält wichtige Informationen über deine Installation, die du gut aufbewahren solltest. Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Account zugeordnet ist, zurücksetzen lassen.
+Diese E-Mail enthält wichtige Informationen über deine Installation, die du gut aufbewahren solltest. Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 ----------------------------
 Benutzername: {USERNAME}

--- a/language/de/email/user_reactivate_account.txt
+++ b/language/de/email/user_reactivate_account.txt
@@ -9,7 +9,7 @@ Bitte bewahre diese E-Mail in deinen Unterlagen auf. Die Daten deines Benutzerko
 Benutzername: {USERNAME}
 ----------------------------
 
-Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Account zugeordnet ist, zurücksetzen lassen.
+Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Um dein Benutzerkonto zu reaktivieren, musst du folgenden Link aufrufen:
 

--- a/language/de/email/user_resend_inactive.txt
+++ b/language/de/email/user_resend_inactive.txt
@@ -8,7 +8,7 @@ Bitte bewahre diese E-Mail in deinen Unterlagen auf. Die Daten deines Benutzerko
 Benutzername: {USERNAME}
 ----------------------------
 
-Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Account zugeordnet ist, zurücksetzen lassen.
+Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Um dein Benutzerkonto zu aktivieren, musst du folgenden Link aufrufen:
 

--- a/language/de/email/user_welcome.txt
+++ b/language/de/email/user_welcome.txt
@@ -10,7 +10,7 @@ Benutzername: {USERNAME}
 Board-URL:    {U_BOARD}
 ----------------------------
 
-Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Account zugeordnet ist, zurücksetzen lassen.
+Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für deine Registrierung.
 

--- a/language/de/email/user_welcome_inactive.txt
+++ b/language/de/email/user_welcome_inactive.txt
@@ -14,7 +14,7 @@ Um dein Benutzerkonto zu aktivieren, musst du folgenden Link aufrufen:
 
 {U_ACTIVATE}
 
-Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Account zugeordnet ist, zurücksetzen lassen.
+Dein Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, kannst du es über die E-Mail-Adresse, die deinem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für deine Registrierung.
 

--- a/language/de_x_sie/acp/users.php
+++ b/language/de_x_sie/acp/users.php
@@ -46,7 +46,7 @@ $lang = array_merge($lang, array(
 	'BAN_ALREADY_ENTERED'	=> 'Die Sperre wurde bereits früher erfolgreich erstellt. Die Liste der Sperren wurde nicht aktualisiert.',
 	'BAN_SUCCESSFUL'		=> 'Sperre erfolgreich hinzugefügt.',
 
-	'CANNOT_BAN_ANONYMOUS'			=> 'Sie können den Gast-Account nicht sperren. Berechtigungen für Gäste können im Register „Berechtigungen“ geändert werden.',
+	'CANNOT_BAN_ANONYMOUS'			=> 'Sie können das Gast-Benutzerkonto nicht sperren. Berechtigungen für Gäste können im Register „Berechtigungen“ geändert werden.',
 	'CANNOT_BAN_FOUNDER'			=> 'Sie können keine Gründer sperren.',
 	'CANNOT_BAN_YOURSELF'			=> 'Sie können sich nicht selber sperren.',
 	'CANNOT_DEACTIVATE_BOT'			=> 'Sie können keine Benutzerkonten von Bots deaktivieren. Deaktivieren Sie stattdessen den Bot in den Einstellungen für Spiders/Robots.',

--- a/language/de_x_sie/common.php
+++ b/language/de_x_sie/common.php
@@ -319,7 +319,7 @@ $lang = array_merge($lang, array(
 		2	=> '%d unsichtbare Mitglieder',
 	),
 	'HIDDEN_USERS_TOTAL'		=> array(
-		1	=> '%d unsichtbares',
+		1	=> '%d unsichtbarer',
 		2	=> '%d unsichtbare',
 	),
 	'HIDE_GUESTS'					=> 'Gäste ausblenden',

--- a/language/de_x_sie/email/admin_welcome_activated.txt
+++ b/language/de_x_sie/email/admin_welcome_activated.txt
@@ -4,6 +4,6 @@ Guten Tag {USERNAME},
 
 Ihr Benutzerkonto auf „{SITENAME}“ wurde von einem Administrator aktiviert. Sie können sich nun anmelden.
 
-Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Account zugeordnet ist, zurücksetzen lassen.
+Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 {EMAIL_SIG}

--- a/language/de_x_sie/email/admin_welcome_inactive.txt
+++ b/language/de_x_sie/email/admin_welcome_inactive.txt
@@ -10,9 +10,9 @@ Benutzername: {USERNAME}
 Board-URL:    {U_BOARD}
 ----------------------------
 
-Ihr Account ist momentan inaktiv und muss erst durch einen Administrator des Boards aktiviert werden, bevor Sie ihn verwenden können. Es wird eine weitere E-Mail versandt, sobald dies geschehen ist.
+Ihr Benutzerkonto ist momentan inaktiv und muss erst durch einen Administrator des Boards aktiviert werden, bevor Sie es verwenden können. Es wird eine weitere E-Mail versandt, sobald dies geschehen ist.
 
-Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Account zugeordnet ist, zurücksetzen lassen.
+Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für Ihre Registrierung.
 

--- a/language/de_x_sie/email/coppa_resend_inactive.txt
+++ b/language/de_x_sie/email/coppa_resend_inactive.txt
@@ -32,9 +32,9 @@ Datum: _______________
 
 -------------------------- HIER AUSSCHNEIDEN -------------------------
 
-Sobald der Administrator dieses Formular per Fax oder Post erhalten hat, wird er Ihren Account aktivieren.
+Sobald der Administrator dieses Formular per Fax oder Post erhalten hat, wird er Ihr Benutzerkonto aktivieren.
 
-Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Account zugeordnet ist, zurücksetzen lassen.
+Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für Ihre Registrierung.
 

--- a/language/de_x_sie/email/coppa_welcome_inactive.txt
+++ b/language/de_x_sie/email/coppa_welcome_inactive.txt
@@ -32,9 +32,9 @@ Datum: _______________
 
 -------------------------- HIER AUSSCHNEIDEN -------------------------
 
-Sobald der Administrator dieses Formular per Fax oder Post erhalten hat, wird er Ihren Account aktivieren.
+Sobald der Administrator dieses Formular per Fax oder Post erhalten hat, wird er Ihr Benutzerkonto aktivieren.
 
-Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Account zugeordnet ist, zurücksetzen lassen.
+Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für Ihre Registrierung.
 

--- a/language/de_x_sie/email/installed.txt
+++ b/language/de_x_sie/email/installed.txt
@@ -4,7 +4,7 @@ Herzlichen Glückwunsch!
 
 Sie haben phpBB erfolgreich auf Ihrem Server installiert.
 
-Diese E-Mail enthält wichtige Informationen über Ihre Installation, die Sie gut aufbewahren sollten. Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Account zugeordnet ist, zurücksetzen lassen.
+Diese E-Mail enthält wichtige Informationen über Ihre Installation, die Sie gut aufbewahren sollten. Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 ----------------------------
 Benutzername: {USERNAME}

--- a/language/de_x_sie/email/user_reactivate_account.txt
+++ b/language/de_x_sie/email/user_reactivate_account.txt
@@ -9,7 +9,7 @@ Bitte bewahren Sie diese E-Mail in Ihren Unterlagen auf. Die Daten Ihres Benutze
 Benutzername: {USERNAME}
 ----------------------------
 
-Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Account zugeordnet ist, zurücksetzen lassen.
+Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Um Ihr Benutzerkonto zu reaktivieren, müssen Sie folgenden Link aufrufen:
 

--- a/language/de_x_sie/email/user_resend_inactive.txt
+++ b/language/de_x_sie/email/user_resend_inactive.txt
@@ -8,7 +8,7 @@ Bitte bewahren Sie diese E-Mail in Ihren Unterlagen auf. Die Daten Ihres Benutze
 Benutzername: {USERNAME}
 ----------------------------
 
-Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Account zugeordnet ist, zurücksetzen lassen.
+Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Um Ihr Benutzerkonto zu aktivieren, müssen Sie folgenden Link aufrufen:
 

--- a/language/de_x_sie/email/user_welcome.txt
+++ b/language/de_x_sie/email/user_welcome.txt
@@ -10,7 +10,7 @@ Benutzername: {USERNAME}
 Board-URL:    {U_BOARD}
 ----------------------------
 
-Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Account zugeordnet ist, zurücksetzen lassen.
+Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für Ihre Registrierung.
 

--- a/language/de_x_sie/email/user_welcome_inactive.txt
+++ b/language/de_x_sie/email/user_welcome_inactive.txt
@@ -14,7 +14,7 @@ Um Ihr Benutzerkonto zu aktivieren, müssen Sie folgenden Link aufrufen:
 
 {U_ACTIVATE}
 
-Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Account zugeordnet ist, zurücksetzen lassen.
+Ihr Passwort wurde sicher in unserer Datenbank gespeichert und kann nicht wiederhergestellt werden. Falls es vergessen werden sollte, können Sie es über die E-Mail-Adresse, die Ihrem Benutzerkonto zugeordnet ist, zurücksetzen lassen.
 
 Vielen Dank für Ihre Registrierung.
 


### PR DESCRIPTION
Info für Christian:

Laut Volltextsuche gibt es mit diesem Branch im gesamten Sprachpaket keine weiteren Vorkommen von "Account" mehr, was sichtbaren Text angeht. Damit ist konsequent alles auf "Benutzerkonto" umgestellt.
