### PR TITLE
[ticket/243] Benutzernamen sperren -> Benutzer sperren

### DIFF
--- a/language/de/mcp.php
+++ b/language/de/mcp.php
@@ -151,7 +151,7 @@ $lang = array_merge($lang, array(
 	'MCP_BAN'					=> 'Sperren',
 	'MCP_BAN_EMAILS'			=> 'E-Mails sperren',
 	'MCP_BAN_IPS'				=> 'IPs sperren',
-	'MCP_BAN_USERNAMES'			=> 'Benutzernamen sperren',
+	'MCP_BAN_USERNAMES'			=> 'Benutzer sperren',
 
 	'MCP_LOGS'						=> 'Moderations-Protokoll',
 	'MCP_LOGS_FRONT'				=> 'Übersicht',

--- a/language/de_x_sie/mcp.php
+++ b/language/de_x_sie/mcp.php
@@ -151,7 +151,7 @@ $lang = array_merge($lang, array(
 	'MCP_BAN'					=> 'Sperren',
 	'MCP_BAN_EMAILS'			=> 'E-Mails sperren',
 	'MCP_BAN_IPS'				=> 'IPs sperren',
-	'MCP_BAN_USERNAMES'			=> 'Benutzernamen sperren',
+	'MCP_BAN_USERNAMES'			=> 'Benutzer sperren',
 
 	'MCP_LOGS'						=> 'Moderations-Protokoll',
 	'MCP_LOGS_FRONT'				=> 'Übersicht',


### PR DESCRIPTION
Die MCP Übersetzung weicht mit dieser Änderung vom Original ab. Passen tut es trotzdem besser. Wollen wir das?

Fixes #243 
