### PR TITLE
Add dist precise again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: php
 
 php:


### PR DESCRIPTION
Wenn wir PHP 5.3.3 oder 5.3.x testen wollen, müssen wir zurück auf die "precise" distribution von Linux: https://github.com/travis-ci/travis-ci/issues/2963#issuecomment-266433258 . Standardmäßig wurde auf "Trusty" (die neue LTS) gestellt. 

Merge before #343 and #344 