### PR TITLE
Korrektur für "Der Syntax..." in BOARD_DATE_FORMAT_EXPLAIN

### DIFF
--- a/language/de_x_sie/ucp.php
+++ b/language/de_x_sie/ucp.php
@@ -156,7 +156,7 @@ $lang = array_merge($lang, array(
 	'BIRTHDAY'					=> 'Geburtstag',
 	'BIRTHDAY_EXPLAIN'			=> 'Wenn Sie ein Jahr angeben, wird an Ihrem Geburtstag Ihr Alter angezeigt.',
 	'BOARD_DATE_FORMAT'			=> 'Mein Datums-Format',
-	'BOARD_DATE_FORMAT_EXPLAIN'	=> 'Der Syntax entspricht der der <a href="http://www.php.net/date">date()</a>-Funktion von PHP.',
+	'BOARD_DATE_FORMAT_EXPLAIN'	=> 'Die Syntax entspricht der der <a href="http://www.php.net/date">date()</a>-Funktion von PHP.',
 	'BOARD_LANGUAGE'			=> 'Meine Sprache',
 	'BOARD_STYLE'				=> 'Mein Board-Style',
 	'BOARD_TIMEZONE'			=> 'Meine Zeitzone',


### PR DESCRIPTION
In `de` ist es korrekt nur hier bei `de_x_sie` ist es falsch.